### PR TITLE
ci: bump checkout to v6 + setup-python to v6 (Node 24 runtime)

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -40,10 +40,10 @@ jobs:
       - name: Install Dart Sass
         run: sudo snap install dart-sass
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - run: python generate-table.py


### PR DESCRIPTION
## Summary

Bumps the two Node-20-era action refs in `hugo.yml` to their Node-24 majors. Part of the org-wide Node 24 baseline cleanup ahead of GitHub's **2026-09-16 Node 20 removal** deadline.

## Action bumps

| action | from | to |
|---|---|---|
| `actions/checkout` | `@v4` | `@v6` |
| `actions/setup-python` | `@v5` | `@v6` |

## Per-PR preflight

- [x] Rolling `@v6` tag verified for both `actions/checkout` (SHA `de0fac2e...`) and `actions/setup-python` (verified 2026-04-29).
- [x] No conflicting Dependabot/Renovate PRs.
- [x] No surprise reusable-workflow dependencies.
- [x] Pages chain (`actions/configure-pages@v5`, `upload-pages-artifact@v3`, `deploy-pages@v4`) already on Node-24 majors — untouched.

## Risk

**Low.** Pure Node-runtime bumps. `actions/checkout@v6` preserves `submodules: recursive` behavior. setup-python v6 input shapes unchanged.

## Validation

This workflow only runs on `push` to `main` (Pages deploy), so PR-time CI doesn't fire. Post-merge: the next deploy will validate. Confirm via:

\`\`\`
gh run view <run-id> --repo trufflesecurity/how-to-rotate --log 2>/dev/null | \\
  grep -E \"Node\\.js (16|20) actions are deprecated\"
\`\`\`

Empty output = green.

## References

- Org-wide plan: \`.cursor/plans/org-wide_node_24_follow-up_a33207ac.plan.md\`
- Approval doc: \`projects/node24-baseline-approval-plan.md\`
- Predecessor PRs (already merged 2026-04-29): trufflesecurity/.github#6, trufflesecurity/.github-private#9

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Simple CI action version bumps; behavior should remain the same aside from underlying runtime and action implementation changes.
> 
> **Overview**
> Updates the GitHub Pages Hugo deploy workflow to use Node.js 24-compatible action majors by bumping `actions/checkout` from `@v4` to `@v6` and `actions/setup-python` from `@v5` to `@v6`, with no other workflow logic changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 21aafed50cd984497e23d2c7bdb6d22736aee99f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->