### PR TITLE
Pin GitHub Actions to SHA digests

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -40,16 +40,16 @@ jobs:
       - name: Install Dart Sass
         run: sudo snap install dart-sass
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
         with:
           submodules: recursive
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: "3.12"
       - run: python generate-table.py
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -62,7 +62,7 @@ jobs:
             --minify \
             --baseURL "https://howtorotate.com/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: ./public
 
@@ -76,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4


### PR DESCRIPTION
## Summary

- Pins all GitHub Actions uses: refs to immutable SHA digests with version comments
- Prevents tag-hijack supply chain attacks
- Version comments allow Renovate to track upstream versions for future updates

## Test plan

- [x] CI passes (workflows resolve to the same commits as the tags they replaced)

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only supply-chain hardening; same action major versions, no application or runtime logic changes.
> 
> **Overview**
> The Hugo **Deploy to GitHub Pages** workflow now references five `actions/*` steps by **immutable commit SHA** instead of floating `@vN` tags, with `# vN` comments preserved on each line.
> 
> Affected steps: **checkout**, **setup-python**, **configure-pages**, **upload-pages-artifact**, and **deploy-pages**. Build and deploy behavior should stay the same; the change hardens CI against mutable tag retargeting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4adae42f298b76aca828f23e6969d91a37e00a9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->