### PR TITLE
ci: bump Pages actions to Node 24 runtime

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -49,7 +49,7 @@ jobs:
       - run: python generate-table.py
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6
       - name: Install Node.js dependencies
         run: "[[ -f package-lock.json || -f npm-shrinkwrap.json ]] && npm ci || true"
       - name: Build with Hugo
@@ -62,7 +62,7 @@ jobs:
             --minify \
             --baseURL "https://howtorotate.com/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: ./public
 
@@ -76,4 +76,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5


### PR DESCRIPTION
## Summary
- Updates three SHA-pinned GitHub Pages actions from Node 20 to Node 24 in the Hugo deploy workflow:
  - `actions/configure-pages` v5 → v6
  - `actions/upload-pages-artifact` v3 → v5 (composite; internally upgrades `upload-artifact@v4` → `@v7`)
  - `actions/deploy-pages` v4 → v5

## Context
The Node 20 runtime for GitHub Actions will require an opt-in environment variable after **June 2, 2026** and will be fully removed **September 16, 2026**. These three actions were the last remaining Node 20 dependencies in this repository.

## Risk
**Low** — these are all first-party GitHub actions with stable APIs. The version bumps are Node runtime changes only; no workflow input/output changes are expected.

## Test plan
- All three SHAs have been verified to resolve to the correct tagged releases and use `node24`
- Merge and confirm the push-to-main deployment succeeds at https://howtorotate.com
- One-commit revert if anything unexpected occurs