### PR TITLE
Bump shared Renovate config to v1.0.2 (GOPRIVATE)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,4 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>trufflesecurity/.github:renovate-config#v1.0.1"]
+  "extends": ["github>trufflesecurity/.github:renovate-config#v1.0.2"]
 }


### PR DESCRIPTION
## Summary

Bumps the shared Renovate config preset from `v1.0.1` to `v1.0.2`.

### What's in v1.0.2

- Adds `GOPRIVATE=github.com/trufflesecurity/*` via the `env` config key, so Renovate's Go toolchain resolves private org modules directly instead of through the public module proxy ([.github#15](https://github.com/trufflesecurity/.github/pull/15))

Without this, Renovate's `go get` fails when updating dependencies in repos that import private `trufflesecurity/*` Go modules (e.g., `interservice-contracts`, `common`).

## Test plan

- [ ] CI passes
- [ ] On next Renovate run, verify artifact update errors for private Go modules are resolved

Made with [Cursor](https://cursor.com)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line Renovate preset version bump with no application or runtime code changes.
> 
> **Overview**
> Updates `.github/renovate.json` to extend the shared **`trufflesecurity/.github` Renovate preset** from **`v1.0.1`** to **`v1.0.2`**.
> 
> That preset bump pulls in **`GOPRIVATE=github.com/trufflesecurity/*`** so Renovate’s Go updates can resolve private org modules instead of failing on the public proxy during dependency bumps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c5d4c1e58ba985538a07f4f3384a0c363ad43398. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->